### PR TITLE
fix: improve module resolution and type declarations

### DIFF
--- a/browser-sdk/package.json
+++ b/browser-sdk/package.json
@@ -2,15 +2,16 @@
   "name": "intmax2-client-sdk",
   "version": "1.0.8",
   "description": "Client SDK for Intmax2",
-  "type": "commonjs",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
     }
   },
   "files": [
@@ -18,9 +19,12 @@
     "README.md"
   ],
   "scripts": {
-    "build:esm": "tsc -p tsconfig.esm.json && pnpm run copy-wasm",
-    "copy-wasm": "mkdir -p dist/wasm && cp -r src/wasm/* dist/wasm/",
-    "prepare": "rimraf dist && pnpm build:esm",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "rimraf dist && pnpm build:cjs && pnpm build:esm && pnpm build:types && pnpm run copy-wasm",
+    "copy-wasm": "mkdir -p dist/esm/wasm dist/cjs/wasm && cp -r src/wasm/* dist/esm/wasm/ && cp -r src/wasm/* dist/cjs/wasm/",
+    "prepare": "pnpm build",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint src --max-warnings=0 --fix"
   },

--- a/browser-sdk/src/shared/constants/index.ts
+++ b/browser-sdk/src/shared/constants/index.ts
@@ -23,7 +23,7 @@ export const MAINNET_ENV = {
 };
 
 export const TESTNET_ENV: SDKUrls = {
-  balance_prover_url: 'https://stage.prover.intmax.io/v1/balance-prover"',
+  balance_prover_url: 'https://stage.prover.intmax.io/v1/balance-prover',
   block_builder_url: 'https://stage.builder.node.intmax.io',
   block_validity_prover_url: 'https://stage.prover.intmax.io/v1/validity-prover',
   store_vault_server_url: 'https://stage.storevault.node.intmax.io',

--- a/browser-sdk/tsconfig.cjs.json
+++ b/browser-sdk/tsconfig.cjs.json
@@ -1,12 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "ESNext",
-    "outDir": "./dist/esm",
+    "module": "CommonJS",
+    "outDir": "./dist/cjs",
     "target": "ES2020",
     "moduleResolution": "Node",
     "declaration": false,
     "sourceMap": true
   },
   "include": ["src/**/*.ts"]
-}
+} 

--- a/browser-sdk/tsconfig.types.json
+++ b/browser-sdk/tsconfig.types.json
@@ -2,11 +2,11 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "ESNext",
-    "outDir": "./dist/esm",
-    "target": "ES2020",
+    "outDir": "./dist/types",
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "moduleResolution": "Node",
-    "declaration": false,
-    "sourceMap": true
+    "target": "ES2020"
   },
   "include": ["src/**/*.ts"]
-}
+} 

--- a/examples/vanilla-js/vite.config.ts
+++ b/examples/vanilla-js/vite.config.ts
@@ -3,9 +3,5 @@ import * as path from 'node:path';
 
 /// THIS FILE IS USED FOR EXAMPLE PURPOSES ONLY
 export default defineConfig({
-  resolve: {
-    alias: {
-      'intmax2-client-sdk': path.resolve(__dirname, '../../browser-sdk/dist'),
-    },
-  },
+  resolve: {},
 });

--- a/server-sdk/src/shared/constants/index.ts
+++ b/server-sdk/src/shared/constants/index.ts
@@ -23,7 +23,7 @@ export const MAINNET_ENV = {
 };
 
 export const TESTNET_ENV: SDKUrls = {
-  balance_prover_url: 'https://stage.prover.intmax.io/v1/balance-prover"',
+  balance_prover_url: 'https://stage.prover.intmax.io/v1/balance-prover',
   block_builder_url: 'https://stage.builder.node.intmax.io',
   block_validity_prover_url: 'https://stage.prover.intmax.io/v1/validity-prover',
   store_vault_server_url: 'https://stage.storevault.node.intmax.io',


### PR DESCRIPTION
- Update browser-sdk package.json to properly handle both CommonJS and ESM builds
- Add separate tsconfig files for different build targets:
  - tsconfig.cjs.json for CommonJS output
  - tsconfig.esm.json for ES Modules output
  - tsconfig.types.json for type declarations
- Fix constants files in both browser-sdk and server-sdk to maintain consistency
- Remove unnecessary resolve config from vite.config.ts as module resolution is now handled correctly by the new tsconfig setup